### PR TITLE
Remove broken labels key in bug_report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,5 @@
 name: Bug Report Or Feature Request
 description: File a bug report
-labels: 
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
The issue template is currently broken. This should fix it.